### PR TITLE
Fix freeze on OS X with Firewall enabled

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,6 @@
 
 'use strict';
 
-var ipv4 = require('ipv4');
 var net = require('net');
 
 var inject = function(port) {
@@ -60,8 +59,7 @@ function detect(port, fn) {
         socket.unref();
       });
       socket.connect({
-        port: port,
-        host: ipv4
+        port: port
       });
     });
   }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "url": "git://github.com/xudafeng/detect-port.git"
   },
   "dependencies": {
-    "commander": "~2.8.1",
-    "ipv4": "0.0.4"
+    "commander": "~2.8.1"
   },
   "devDependencies": {
     "mocha": "2.2.4",


### PR DESCRIPTION
It appears that letting Node.js use localhost by default is much faster (a few seconds instead of a minute) than using external IP for determining whether the port is busy.

Fixes #3.

I tested this on OS X, Windows, and Linux.